### PR TITLE
Fix reading of extra bits for distance codes with >8 extra bits

### DIFF
--- a/source/jsunzip.js
+++ b/source/jsunzip.js
@@ -354,7 +354,7 @@ this.read_bits = function(d, num, base)
         d.tag = d.tag | (d.source.charCodeAt(d.sourceIndex++) & 0xff) << d.bitcount;
         d.bitcount += 8;
     }
-    val = d.tag & (0xff >> (8 - num));
+    val = d.tag & (0xffff >> (16 - num));
     d.tag >>= num;
     d.bitcount -= num;
     return val + base;


### PR DESCRIPTION
Extra bits for distance codes of 20 or greater (where there are more
than 8 bits) were not being read. This meant the wrong offset was being
calculated, resulting in the wrong string of bytes being copied into
the inflated block.

This patch modifies function read_bits to handle up to 16 bits, which
means the correct offset is calculated.
